### PR TITLE
Fix dark mode toggle and custom ratio input

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -51,6 +51,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   darkModeToggle?.addEventListener('click', () => {
     document.body.classList.toggle('dark');
+    document.body.classList.toggle('light');
+  });
+
+  document.getElementById('useCustomRatio')?.addEventListener('change', (e) => {
+    const customRatio = document.getElementById('customRatio');
+    if (!customRatio) return;
+    customRatio.classList.toggle('hidden', !e.target.checked);
   });
 
   languageToggle?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- toggle both `dark` and `light` classes when switching dark mode so light theme works
- show and hide custom ratio input based on checkbox state

## Testing
- `npm test` *(fails: package.json missing)*